### PR TITLE
Implement web interface for pipeline deletion

### DIFF
--- a/web/static/dashboard.html
+++ b/web/static/dashboard.html
@@ -404,6 +404,11 @@
             actions.push(`<button class="btn" onclick="viewPipeline(${pipeline.id})">👁️ View</button>`);
             actions.push(`<button class="btn" onclick="downloadPipeline(${pipeline.id}, '${pipeline.name}')">⬇️ Download</button>`);
 
+            // Only allow delete if pipeline is not running
+            if (pipeline.state !== 'RUNNING' && pipeline.state !== 'PAUSED') {
+                actions.push(`<button class="btn btn-danger" onclick="deletePipeline(${pipeline.id}, '${pipeline.name}')">🗑️ Delete</button>`);
+            }
+
             return actions.join('');
         }
 
@@ -546,6 +551,27 @@
                 }
             } catch (error) {
                 showMessage(`Error resuming pipeline: ${error.message}`, 'error');
+            }
+        }
+
+        async function deletePipeline(id, name) {
+            // Confirm deletion
+            if (!confirm(`Are you sure you want to delete pipeline "${name}"?\n\nThis action cannot be undone and will remove:\n- Pipeline configuration\n- All execution history\n- All associated data`)) {
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/v1/pipelines/${id}`, { method: 'DELETE' });
+                const data = await response.json();
+
+                if (data.success) {
+                    showMessage(`Pipeline "${name}" deleted successfully`, 'success');
+                    setTimeout(refreshDashboard, 1000);
+                } else {
+                    showMessage(`Failed to delete pipeline: ${data.error}`, 'error');
+                }
+            } catch (error) {
+                showMessage(`Error deleting pipeline: ${error.message}`, 'error');
             }
         }
 

--- a/web/static/pipeline-detail.html
+++ b/web/static/pipeline-detail.html
@@ -423,6 +423,9 @@
                             <button class="btn" onclick="downloadYAML()">
                                 ⬇️ Download YAML
                             </button>
+                            <button class="btn btn-danger" id="btnDelete" onclick="deletePipeline()" disabled>
+                                🗑️ Delete Pipeline
+                            </button>
                         </div>
                     </div>
 
@@ -937,21 +940,29 @@
             const btnPause = document.getElementById('btnPause');
             const btnResume = document.getElementById('btnResume');
             const btnStop = document.getElementById('btnStop');
+            const btnDelete = document.getElementById('btnDelete');
 
             // Reset all
             btnStart.disabled = true;
             btnPause.disabled = true;
             btnResume.disabled = true;
             btnStop.disabled = true;
+            btnDelete.disabled = true;
 
             if (state === 'RUNNING') {
                 btnPause.disabled = false;
                 btnStop.disabled = false;
+                // Cannot delete while running
             } else if (state === 'PAUSED') {
                 btnResume.disabled = false;
                 btnStop.disabled = false;
+                // Cannot delete while paused
             } else if (enabled && (state === 'CREATED' || state === 'COMPLETED' || state === 'ERROR' || state === 'STOPPED')) {
                 btnStart.disabled = false;
+                btnDelete.disabled = false; // Can delete when not running
+            } else {
+                // Disabled pipelines can still be deleted
+                btnDelete.disabled = false;
             }
         }
 
@@ -1017,6 +1028,30 @@
                 }
             } catch (error) {
                 alert('Error resuming pipeline: ' + error.message);
+            }
+        }
+
+        async function deletePipeline() {
+            if (!pipelineId || !pipelineData) return;
+
+            // Confirm deletion
+            const pipelineName = pipelineData.name || `Pipeline #${pipelineId}`;
+            if (!confirm(`Are you sure you want to delete pipeline "${pipelineName}"?\n\nThis action cannot be undone and will remove:\n- Pipeline configuration\n- All execution history\n- All associated data\n\nType the pipeline name to confirm deletion.`)) {
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/v1/pipelines/${pipelineId}`, { method: 'DELETE' });
+                const data = await response.json();
+                if (data.success) {
+                    alert(`Pipeline "${pipelineName}" deleted successfully.\n\nRedirecting to dashboard...`);
+                    // Redirect to dashboard after successful deletion
+                    window.location.href = '/';
+                } else {
+                    alert('Failed to delete pipeline: ' + data.error);
+                }
+            } catch (error) {
+                alert('Error deleting pipeline: ' + error.message);
             }
         }
 


### PR DESCRIPTION
Add delete functionality to both dashboard and pipeline detail pages:

Dashboard (web/static/dashboard.html):
- Add Delete button to pipeline actions (only when not running/paused)
- Implement deletePipeline() function with confirmation dialog
- Display success/error messages after deletion
- Auto-refresh dashboard after successful deletion

Pipeline Detail (web/static/pipeline-detail.html):
- Add Delete button to pipeline controls panel
- Update control state logic to enable delete when pipeline is stopped
- Implement deletePipeline() function with confirmation
- Redirect to dashboard after successful deletion

Features:
- Prevents deletion of running or paused pipelines
- Requires user confirmation with detailed warning
- Shows clear error messages if deletion fails
- Integrates with existing DELETE /api/v1/pipelines/{id} endpoint
- Consistent styling with existing UI buttons

The backend API endpoint was already implemented in the new-structure branch.